### PR TITLE
make catmull clark family algorithms support quad meshes

### DIFF
--- a/Model-Modifier/src/main.cpp
+++ b/Model-Modifier/src/main.cpp
@@ -353,10 +353,10 @@ int main()
                 objectVB.AssignData(mesh.m_OutVertices, mesh.m_OutNumVert * sizeof(float), DRAW_MODE::STATIC);
                 objectIB.AssignData(mesh.m_OutIndices, mesh.m_OutNumIdx, DRAW_MODE::STATIC);
             }
-            if (ImGui::Button("Beehive Surface"))
+            if (ImGui::Button("Beehive Surface (tri)"))
             {
                 Surface BH(obj);
-                obj = BH.Beehive(); 
+                obj = BH.Beehive(3); 
                 mesh.Rebuild(obj); // rebuild mesh based on object info
                 numFaces = static_cast<int>(mesh.m_Object.m_FaceIndices.size()); // update number of faces
 
@@ -364,10 +364,21 @@ int main()
                 objectVB.AssignData(mesh.m_OutVertices, mesh.m_OutNumVert * sizeof(float), DRAW_MODE::STATIC);
                 objectIB.AssignData(mesh.m_OutIndices, mesh.m_OutNumIdx, DRAW_MODE::STATIC);
             }
-            if (ImGui::Button("SnowFlake Surface"))
+            if (ImGui::Button("Beehive Surface (quad)"))
+            {
+                Surface BH(obj);
+                obj = BH.Beehive(4);
+                mesh.Rebuild(obj); // rebuild mesh based on object info
+                numFaces = static_cast<int>(mesh.m_Object.m_FaceIndices.size()); // update number of faces
+
+                objectVA.Bind();
+                objectVB.AssignData(mesh.m_OutVertices, mesh.m_OutNumVert * sizeof(float), DRAW_MODE::STATIC);
+                objectIB.AssignData(mesh.m_OutIndices, mesh.m_OutNumIdx, DRAW_MODE::STATIC);
+            }
+            if (ImGui::Button("SnowFlake Surface (tri)"))
             {
                 Surface SF(obj);
-                obj = SF.Snowflake();
+                obj = SF.Snowflake(3);
                 mesh.Rebuild(obj); // rebuild mesh based on object info
                 numFaces = static_cast<int>(mesh.m_Object.m_FaceIndices.size()); // update number of faces
 
@@ -375,10 +386,32 @@ int main()
                 objectVB.AssignData(mesh.m_OutVertices, mesh.m_OutNumVert * sizeof(float), DRAW_MODE::STATIC);
                 objectIB.AssignData(mesh.m_OutIndices, mesh.m_OutNumIdx, DRAW_MODE::STATIC);
             }
-            if (ImGui::Button("Catmull Clark Subdivision Surface"))
+            if (ImGui::Button("SnowFlake Surface (quad)"))
+            {
+                Surface SF(obj);
+                obj = SF.Snowflake(4);
+                mesh.Rebuild(obj); // rebuild mesh based on object info
+                numFaces = static_cast<int>(mesh.m_Object.m_FaceIndices.size()); // update number of faces
+
+                objectVA.Bind();
+                objectVB.AssignData(mesh.m_OutVertices, mesh.m_OutNumVert * sizeof(float), DRAW_MODE::STATIC);
+                objectIB.AssignData(mesh.m_OutIndices, mesh.m_OutNumIdx, DRAW_MODE::STATIC);
+            }
+            if (ImGui::Button("Catmull Clark Subdivision Surface (tri)"))
             {
                 Surface CC(obj);
-                obj = CC.CatmullClark();
+                obj = CC.CatmullClark(3);
+                mesh.Rebuild(obj); // rebuild mesh based on object info
+                numFaces = static_cast<int>(mesh.m_Object.m_FaceIndices.size()); // update number of faces
+
+                objectVA.Bind();
+                objectVB.AssignData(mesh.m_OutVertices, mesh.m_OutNumVert * sizeof(float), DRAW_MODE::STATIC);
+                objectIB.AssignData(mesh.m_OutIndices, mesh.m_OutNumIdx, DRAW_MODE::STATIC);
+            }
+            if (ImGui::Button("Catmull Clark Subdivision Surface (quad)"))
+            {
+                Surface CC(obj);
+                obj = CC.CatmullClark(4);
                 mesh.Rebuild(obj); // rebuild mesh based on object info
                 numFaces = static_cast<int>(mesh.m_Object.m_FaceIndices.size()); // update number of faces
 

--- a/Model-Modifier/src/scene/surface/Surface.h
+++ b/Model-Modifier/src/scene/surface/Surface.h
@@ -48,13 +48,14 @@ public:
 	// helper
 	glm::vec3 ComputeFaceNormal(FaceRecord face);
 	glm::vec3 ComputeFaceNormal(glm::vec3 pos0, glm::vec3 pos1, glm::vec3 pos2);
-	Object CCOutputOBJ(std::vector<glm::vec3> edgePoints);
+	Object CCOutputOBJ3(std::vector<glm::vec3> edgePoints);
+	Object CCOutputOBJ4(std::vector<glm::vec3> edgePoints);
 	glm::mat4 ComputeQuadric(VertexRecord v0);
 
 	// Modification algorithms
-	Object Beehive();
-	Object Snowflake();
-	Object CatmullClark();
+	Object Beehive(int n);
+	Object Snowflake(int n);
+	Object CatmullClark(int n);
 	Object DooSabin();
 	Object Loop();
 	Object QEM();


### PR DESCRIPTION
partially resolves #4 in https://github.com/jasonlmfong/Model-Modifier/issues/23
now supports quad mesh modification for Catmull-Clark family algorithms